### PR TITLE
Support standard TLS by default

### DIFF
--- a/server.go
+++ b/server.go
@@ -83,7 +83,7 @@ func (s *Server) SetDatagramChannelSize(size int) {
 func defaultTlsPeerName(tlsConn *tls.Conn) (tlsPeer string, ok bool) {
 	state := tlsConn.ConnectionState()
 	if len(state.PeerCertificates) <= 0 {
-		return "", false
+		return "", true
 	}
 	cn := state.PeerCertificates[0].Subject.CommonName
 	return cn, true


### PR DESCRIPTION
By default, even if *tls.Config is configured to accept client connections over standard TLS, when running server.ListenTCPTLS(), the defaultTlsPeerNameFunc will result in termination of client connections if no peer certificates are presented. Although enforcing mutual TLS is a good security practice, in practice, there are many third-party syslog client applications that do not allow upload of client certificates for mutual TLS. Therefore, this PR is aimed at making go-syslog more robust by supporting standard TLS connections out-of-the-box.